### PR TITLE
Tweak theme setting storage and distance from neutron star/black hole rule.

### DIFF
--- a/src/rules/x_distance.rs
+++ b/src/rules/x_distance.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct RuleXDistance {
     pub condition: Condition,
+    pub all: bool,
 }
 
 impl Rule for RuleXDistance {
@@ -40,11 +41,21 @@ impl Rule for RuleXDistance {
                 continue;
             }
             let star = &sp.star;
-            if x_stars
-                .iter()
-                .any(|p| self.condition.eval(star.position.distance_from(p) as f32))
-            {
-                result.push(index)
+            if self.all {
+                if x_stars
+                    .iter()
+                    .all(|p| self.condition.eval(star.position.distance_from(p) as f32))
+                {
+                    result.push(index)
+                }
+            }
+            else {
+                if x_stars
+                    .iter()
+                    .any(|p| self.condition.eval(star.position.distance_from(p) as f32))
+                {
+                    result.push(index)
+                }
             }
         }
         result

--- a/web/src/partials/Header.tsx
+++ b/web/src/partials/Header.tsx
@@ -1,5 +1,5 @@
 import styles from "./Header.module.css"
-import { useStore } from "../store"
+import { setDarkMode, useStore } from "../store"
 import { A } from "@solidjs/router"
 import { IoContrast, IoLogoGithub } from "solid-icons/io"
 import { Component } from "solid-js"
@@ -37,7 +37,10 @@ const Header: Component = () => {
                 </a>
                 <div
                     class={styles.icon}
-                    onClick={() => setStore("settings", "darkMode", (x) => !x)}
+                    onClick={() => {
+                        setDarkMode(!store.settings.darkMode)
+                        setStore("settings", "darkMode", (x) => !x)
+                    }}
                 >
                     <IoContrast />
                 </div>

--- a/web/src/partials/RuleEditor.module.css
+++ b/web/src/partials/RuleEditor.module.css
@@ -108,3 +108,7 @@
 .selectConditionType {
     width: 80px;
 }
+
+.selectAllOrAny {
+    width: 50px;
+}

--- a/web/src/partials/RuleEditor.tsx
+++ b/web/src/partials/RuleEditor.tsx
@@ -431,8 +431,17 @@ const EditXDistance: Component<{
                 emptyValue={-1}
                 error={condition().value <= 0}
                 disabled={props.disabled}
-            />
-            ly away from any black hole / neutron star.
+            />{" "}
+            ly away from{" "}
+            <Select
+                class={styles.selectAllOrAny}
+                value={props.value.all}
+                onChange={(all) => props.onChange({ ...props.value, all })}
+                options={[false, true]}
+                getLabel={(all) => (all ? "all" : "any")}
+                disabled={props.disabled}
+            />{" "}
+            black hole / neutron star{props.value.all ? "s" : ""}.
         </>
     )
 }
@@ -884,6 +893,7 @@ const rules: SimpleRule[] = [
             type: ConditionType.Lte,
             value: 0,
         },
+        all: false,
     },
     {
         type: RuleType.GasCount,

--- a/web/src/partials/StarView.tsx
+++ b/web/src/partials/StarView.tsx
@@ -7,6 +7,7 @@ import {
     gasNames,
     gasOrder,
     getStarType,
+    metersPerAU,
     nearestDistanceFrom,
     planetTypes,
     romans,
@@ -352,6 +353,18 @@ const PlanetView: Component<{ star: Star; planet: Planet }> = (props) => {
                 </Show>
                 <Show when={Math.abs(props.planet.obliquity) > 70}>
                     <div class={styles.row}>Horizontal Rotation</div>
+                </Show>
+                <Show when={props.planet.orbitAround == null}>
+                    <div class={styles.row}>
+                        <div class={styles.field}>Orbit Radius</div>
+                        <div class={styles.value}>
+                            {toPrecision(
+                                props.planet.orbitRadius * metersPerAU,
+                                0,
+                            )}{" "}
+                            m
+                        </div>
+                    </div>
                 </Show>
                 <div class={styles.row}>
                     <div class={styles.field}>Wind Power</div>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -2,9 +2,29 @@ import { createContext, useContext } from "solid-js"
 import { SetStoreFunction } from "solid-js/store"
 import { defaultResourceMultipler, defaultStarCount } from "./util"
 
+const localStorageKey = "dsp-seed-finder-theme";
+const initializeTheme = () => {
+    let theme;
+
+    if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
+        theme = localStorage.getItem(localStorageKey) === "dark" ? "dark" : "light";
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        theme = "dark";
+    } else {
+        theme = "light";
+    }
+    return theme;
+}
+
+export const setDarkMode = (isDarkMode: boolean) => {
+    if (typeof localStorage !== "undefined") {
+        localStorage.setItem(localStorageKey, isDarkMode ? "dark" : "light");
+    }
+}
+
 export const defaultStore: Store = {
     settings: {
-        darkMode: window.matchMedia("(prefers-color-scheme: dark)").matches,
+        darkMode: initializeTheme() === "dark",
         view: {
             starCount: defaultStarCount,
             resourceMultipler: defaultResourceMultipler,

--- a/web/src/types.d.ts
+++ b/web/src/types.d.ts
@@ -166,6 +166,7 @@ declare global {
         }
         export type XDistance = {
             type: RuleType.XDistance
+            all: boolean
             condition: Condition
         }
         export type SpectrDistance = {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -75,6 +75,7 @@ export function constructMultiRule(multiRules: MultiRule[][]): CompositeRule {
 export const minStarCount = 32
 export const maxStarCount = 64
 export const defaultStarCount = 64
+export const metersPerAU = 40000
 
 export const resourceMultiplers: ReadonlyArray<float> = [
     0.1, 0.5, 0.8, 1, 1.5, 2, 3, 5, 8, 100,


### PR DESCRIPTION
- Also store dark mode setting in local storage, so that if the user opens a found universe/star in a new tab their theme setting is applied to the new tab.
- Allow specifying whether only one of the neutron star/black hole should match the distance requirements, or both of them should match the distance requirements (options "any", "all").
- Display planet orbit radius for planets that are not satellites (for easy comparison to the max dyson sphere radius).