### PR TITLE
Fix unipolar magnet vein search returning no results

### DIFF
--- a/src/data/planet.rs
+++ b/src/data/planet.rs
@@ -525,6 +525,11 @@ impl<'a> Planet<'a> {
         let theme = self.get_theme();
         if vein_type.is_rare() {
             theme.rare_veins.contains(vein_type)
+        } else if vein_type == &VeinType::Mag {
+            matches!(
+                self.star.star_type,
+                StarType::BlackHole | StarType::NeutronStar
+            )
         } else {
             let vein_index = *vein_type as i32;
             if let Some(x) = theme.vein_spot.get((vein_index - 1) as usize) {


### PR DESCRIPTION
Hi, I was having an issue where if I made the ONLY search criteria to look for seeds that had unipolar magnets (which should be every seed), I got zero results.

I forked and pulled down locally and threw claude at the problem.

I built locally and ran same test and now it returns results.

You can test for yourself by going to the public website and creating a search with a single rule:

- Has at least 1 star(s) that safisfy this ruleset, then set the ruleset to "Vein amount has unipolar magnet and the estimated amount is at least 10000000"

This will fail to return any result. (At least it did for me)

Using the branch that I'm submitting below, it now returns results.

I have done NO additional testing, but I did ask Claude for unintended consequences:


Claude spam below:

===================


can_have_vein() checked the theme's static vein_spot array for Mag, which has no slot for it (themes only define 7 vein entries). This caused every planet to be skipped before its veins were counted, even for Black Hole and Neutron Star systems where Mag veins do spawn.

Fix by handling VeinType::Mag explicitly: a planet can have Mag veins if and only if its star is a Black Hole or Neutron Star, matching the logic already present in get_estimated_veins().

====================

> are there any possible unintended consequences of this PR fix?

Let me check every call site of can_have_vein to trace the full impact:

  Searched for 1 pattern, read 1 file

can_have_vein is only called in those two places. Let me also check get_actual_veins to make sure Mag is handled correctly there too — since get_actual_vein now reaches it:

  Searched for 1 pattern, read 1 file

The analysis is clean. Here's the full picture:

No unintended consequences. Specifically:

1. can_have_vein has exactly 2 callers — both in get_avg_vein and get_actual_vein, and both already have an early return of 0.0 for Mag on non-BH/NS stars. The new branch in can_have_vein is therefore unreachable for any non-BH/NS star — the function never even gets called for those cases.
2. get_actual_veins (line 912-925) mirrors get_estimated_veins exactly — it also sets vein_spots[14] for BH/NS planets, so actual vein data for Mag is correctly generated there too. The fix works correctly for both the estimated and actual search modes.
3. No frontend code calls can_have_vein directly — it's Rust-only, not exposed via WASM bindings.
4. The fix doesn't change behavior for any other vein type — it only adds a new branch specifically for VeinType::Mag, leaving all other paths untouched.

The fix is as narrowly scoped as it looks.